### PR TITLE
Feature: Operator connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-redux": "^4.4.5",
     "redux": "^3.6.0",
     "redux-logger": "^2.8.2",
-    "socket.io-client": "^1.7.3",
+    "socket.io-client": "^2.0.3",
     "whatwg-fetch": "^2.0.2"
   },
   "devDependencies": {

--- a/src/components/ClientList/ClientList.jsx
+++ b/src/components/ClientList/ClientList.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { loadChats } from '../../store/Chat';
+
 import ClientCard from '../ClientCard/ClientCard.jsx';
+import { loadChats } from '../../store/Chat';
 import './ClientList.css';
 
 class ClientList extends Component {

--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -1,9 +1,17 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import Button from '../Button/Button.jsx';
+import { addMessage } from '../../store/Chat';
 import './InputBar.css';
 
 class InputBar extends Component {
+  static propTypes = {
+    operator: PropTypes.string,
+    activeId: PropTypes.string,
+    dispatch: PropTypes.func.isRequired,
+  }
 
   state = {
     chatText: '',
@@ -12,7 +20,17 @@ class InputBar extends Component {
   // dummy function to stub out sending message via socket
   // this will eventually happen via redux actions.
   sendChat = () => {
+    const { chatText } = this.state;
+    const { dispatch, activeId, operator } = this.props;
+
     console.log('dispatch action for sending chat message here');
+
+    dispatch(addMessage({
+      author: operator,
+      chat: activeId,
+      content: chatText,
+      timestamp: (new Date()).toISOString(),
+    }));
   }
 
   handleChange = (e) => {
@@ -31,5 +49,17 @@ class InputBar extends Component {
   }
 }
 
+const mapStateToProps = state => ({
+  activeId: state.chat.activeId,
+  operator: state.chat.config.operator,
+});
 
-export default InputBar;
+const mapDispatchToProps = dispatch => ({
+  dispatch,
+});
+
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(InputBar);

--- a/src/components/InputBar/InputBar.jsx
+++ b/src/components/InputBar/InputBar.jsx
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Button from '../Button/Button.jsx';
-import { addMessage } from '../../store/Chat';
+import { sendMessage, typing } from '../../store/Chat';
 import './InputBar.css';
+
+// TODO: Move to a constants file
+const KEY_ENTER = 13;
 
 class InputBar extends Component {
   static propTypes = {
@@ -17,15 +20,31 @@ class InputBar extends Component {
     chatText: '',
   }
 
+  onKeyPress = (e) => {
+    const { key, keyCode, shiftKey, ctrlKey, altKey } = e;
+    const { dispatch } = this.props;
+    console.log(`INPUT KEYPRESS ${key} (${keyCode}), SHIFT ${shiftKey}, CTRL ${ctrlKey}, ALT ${altKey}`);
+
+    if (keyCode === KEY_ENTER) {
+      if (!shiftKey) {
+        console.log('SENDING MESSAGE ...');
+
+        this.sendChat();
+        this.setState({ [e.target.name]: '' });
+
+        event.preventDefault();
+      }
+    }
+    dispatch(typing());
+  }
+
   // dummy function to stub out sending message via socket
   // this will eventually happen via redux actions.
   sendChat = () => {
     const { chatText } = this.state;
     const { dispatch, activeId, operator } = this.props;
 
-    console.log('dispatch action for sending chat message here');
-
-    dispatch(addMessage({
+    dispatch(sendMessage({
       author: operator,
       chat: activeId,
       content: chatText,
@@ -42,7 +61,12 @@ class InputBar extends Component {
   render () {
     return (
       <div className="InputBar">
-        <textarea onChange={this.handleChange} name="chatText" placeholder="text here, dummy" />
+        <textarea
+          onChange={this.handleChange}
+          onKeyDown={this.onKeyPress}
+          name="chatText"
+          placeholder="Say something meaningful &hellip;"
+        />
         <Button variant="send" onClick={this.sendChat} >Send</Button>
       </div>
     );

--- a/src/components/InputBar/InputBar.test.jsx
+++ b/src/components/InputBar/InputBar.test.jsx
@@ -7,12 +7,19 @@ import InputBar from './InputBar.jsx';
 const store = {
   subscribe: jest.fn(),
   dispatch: jest.fn(),
-  getState: jest.fn(() => ({ })),
+  getState: jest.fn(() => ({
+    chat: {
+      activeId: 'TEST',
+      config: {
+        operator: 'TEST',
+      },
+    },
+  })),
 };
 
 describe('InputBar', () => {
   it('matches snapshot', () => {
-    const component = shallow(<InputBar store={store} />);
+    const component = shallow(<InputBar store={store} socket={{}} />);
 
     expect(component).toMatchSnapshot();
   });

--- a/src/components/InputBar/__snapshots__/InputBar.test.jsx.snap
+++ b/src/components/InputBar/__snapshots__/InputBar.test.jsx.snap
@@ -1,16 +1,14 @@
 exports[`InputBar matches snapshot 1`] = `
-<div
-  className="InputBar">
-  <textarea
-    name="chatText"
-    onChange={[Function]}
-    placeholder="text here, dummy" />
-  <Button
-    disabled={false}
-    onClick={[Function]}
-    type="button"
-    variant="send">
-    Send
-  </Button>
-</div>
+<InputBar
+  activeId="TEST"
+  dispatch={[Function]}
+  operator="TEST"
+  socket={Object {}}
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "subscribe": [Function],
+    }
+  } />
 `;

--- a/src/components/Message/Message.css
+++ b/src/components/Message/Message.css
@@ -6,21 +6,40 @@
   float: left;
   font-size: 12px;
   letter-spacing: 1px;
+  list-style: none;
   margin-top: 6px;
   margin-right: 6px;
   max-width: 45%;
+  min-width: 25%;
   padding: 10px;
   text-align: left;
 }
 
+.Message__client ul li {
+  text-align: right;
+}
+
 .Message__operator {
   align-self: flex-start;
-  background: rgb(230, 126, 34);
-  border-radius: 2px;
+  background: #0a6bef;
+  border-radius: 10px 10px 10px 0;
   color: white;
   font-size: 12px;
   letter-spacing: 1px;
+  list-style: none;
   padding: 0.5rem;
   margin: 0.5rem;
   max-width: 45%;
+  min-width: 25%;
+}
+
+.Message__operator ul,
+.Message__client ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.Message__operator ul li {
+  text-align: left;
 }

--- a/src/components/Message/Message.jsx
+++ b/src/components/Message/Message.jsx
@@ -8,15 +8,32 @@ import './Message.css';
 
 const Message = (props) => {
   const msgClass = () => (
-    props.type === 'operator' ? 'Message__operator' : 'Message__client'
+    props.author.indexOf('client') >= 0 ? 'Message__client' : 'Message__operator'
   );
 
-  return <div className={msgClass()}>{props.children}</div>;
+  const { author } = props;
+  const content = props.content.map((message, index) => <li key={index}>{message}</li>);
+
+  let message = (
+    <div>
+      <ul>
+        {content}
+      </ul>
+    </div>
+  );
+
+  return (
+    <li className={msgClass()} style={{ clear: 'both' }}>
+      {message}
+    </li>
+  );
 };
 
 Message.propTypes = {
-  children: PropTypes.node.isRequired,
-  type: PropTypes.string.isRequired,
+  author: PropTypes.string.isRequired,
+  content: PropTypes.arrayOf(
+    PropTypes.string,
+  ),
 };
 
 

--- a/src/components/Message/Message.test.jsx
+++ b/src/components/Message/Message.test.jsx
@@ -14,7 +14,7 @@ const store = {
 
 describe('MessageList', () => {
   it('matches snapshot', () => {
-    const component = shallow(<Message type="operator">test message</Message>);
+    const component = shallow(<Message author={'operator.steve'} content={['test message']} />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/Message/__snapshots__/Message.test.jsx.snap
+++ b/src/components/Message/__snapshots__/Message.test.jsx.snap
@@ -1,6 +1,17 @@
 exports[`MessageList matches snapshot 1`] = `
-<div
-  className="Message__operator">
-  test message
-</div>
+<li
+  className="Message__operator"
+  style={
+    Object {
+      "clear": "both",
+    }
+  }>
+  <div>
+    <ul>
+      <li>
+        test message
+      </li>
+    </ul>
+  </div>
+</li>
 `;

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -13,7 +13,12 @@ import './MessageList.css';
 
 class MessageList extends Component {
   static propTypes = {
-    messages: PropTypes.array.isRequired,
+    messages: PropTypes.arrayOf(
+      PropTypes.shape({
+        author: PropTypes.string,
+        content: PropTypes.arrayOf(PropTypes.string),
+      }),
+    ).isRequired,
     config: PropTypes.object.isRequired,
     activeId: PropTypes.string,
     dispatch: PropTypes.func.isRequired,
@@ -37,7 +42,7 @@ class MessageList extends Component {
 
       return activeMsgs.map((msg, index) => {
         const key = `${index}_${msg.chat}`;
-        return <Message key={key} type={msg.author}>{msg.content}</Message>;
+        return <Message key={key} author={msg.author} content={msg.content} />;
       });
     };
 

--- a/src/init.jsx
+++ b/src/init.jsx
@@ -5,15 +5,12 @@ import { Provider } from 'react-redux';
 import createLogger from 'redux-logger';
 
 import Application from './components/Application/Application.jsx';
-import socketInit from './store/socket_init.js';
+import socketInit, { socketMessageHook } from './store/socket_init.js';
 
 // Reducers
 import chat from './store/Chat';
 import ui from './store/UI';
 import socket from './store/Socket';
-
-// Middleware
-const logger = createLogger();        // TODO: make DEV only.
 
 // Create redux store
 const store = createStore(
@@ -23,7 +20,7 @@ const store = createStore(
     socket,
   }),
 
-  applyMiddleware(logger),             // NOTE: `logger` must come last
+  applyMiddleware(socketMessageHook),
 );
 
 
@@ -35,5 +32,6 @@ ReactDOM.render(
   <Provider store={store}>
     <Application />
   </Provider>,
+
   document.getElementById('app'),
 );

--- a/src/store/Chat/index.js
+++ b/src/store/Chat/index.js
@@ -88,14 +88,12 @@ export function setOperatorFilter (payload) {
   };
 }
 
-
 export function toggleChatOpen (payload) {
   return {
     type: TOGGLE_OPEN,
     payload,
   };
 }
-
 
 export function addChat (payload) {
   return {
@@ -116,6 +114,7 @@ export function addMessage (payload) {
 //
 
 function ChatReducer (state = initialState, action) {
+  console.log('CHAT', action);
   switch (action.type) {
     case LOAD_CHATS_SUCCESS:
       return {

--- a/src/store/Chat/index.js
+++ b/src/store/Chat/index.js
@@ -34,7 +34,10 @@ const SET_ACTIVE_CHAT = 'CHAT_SET_ACTIVE_CHAT';
 
 const TOGGLE_OPEN = 'CHAT_TOGGLE_OPEN';
 
-const ADD_MESSAGE = 'CHAT_ADD_MESSAGE';
+const TYPING = 'CHAT_TYPING';
+const SEND_MESSAGE = 'CHAT_MESSAGE_OPERATOR';
+const RECEIVE_MESSAGE = 'CHAT_MESSAGE_CLIENT';
+
 const ADD_CHAT = 'CHAT_ADD_CHAT';
 
 
@@ -102,9 +105,22 @@ export function addChat (payload) {
   };
 }
 
-export function addMessage (payload) {
+export function typing () {
   return {
-    type: ADD_MESSAGE,
+    type: TYPING,
+  };
+}
+
+export function sendMessage (payload) {
+  return {
+    type: SEND_MESSAGE,
+    payload,
+  };
+}
+
+export function receiveMessage (payload) {
+  return {
+    type: RECEIVE_MESSAGE,
     payload,
   };
 }
@@ -114,7 +130,11 @@ export function addMessage (payload) {
 //
 
 function ChatReducer (state = initialState, action) {
+  let messages = [];
+  let sortedPayload = [];
+
   console.log('CHAT', action);
+
   switch (action.type) {
     case LOAD_CHATS_SUCCESS:
       return {
@@ -160,9 +180,34 @@ function ChatReducer (state = initialState, action) {
       //   });
       // }
 
+      // We need to run through the entire array of messages and aggregate them
+      //  into similar sets
+
+      if (action.payload.length > 0) {
+        sortedPayload = action.payload.sort((curr, next) => (
+          new Date(curr.timestamp) - new Date(next.timestamp)
+        ));
+        // There should be an algorithm here that would speed things up
+
+        for (let i = 0; i < sortedPayload.length; i += 1) {
+          // All we have to do is see if the last message has the same author
+
+          if (messages.length > 0 &&
+            messages[messages.length - 1].author === sortedPayload[i].author) {
+            // If it is the same author, do our usual slice magic
+            messages[messages.length - 1].content.push(sortedPayload[i].content);
+          } else {
+            messages.push({
+              ...sortedPayload[i],
+              content: [sortedPayload[i].content],
+            });
+          }
+        }
+      }
+
       return {
         ...state,
-        messages: [...action.payload],
+        messages,
       };
     }
 
@@ -217,10 +262,56 @@ function ChatReducer (state = initialState, action) {
         chats: [...state.chats, action.payload],
       };
 
-    case ADD_MESSAGE:
+    case SEND_MESSAGE:
+      if (state.messages.length > 0 &&
+        // TODO: This should check if author === operator username
+        state.messages[state.messages.length - 1].author === action.payload.author) {
+        messages = [
+          ...state.messages[state.messages.length - 1].content,
+          action.payload.content,
+        ];
+
+        return {
+          ...state,
+          messages: [
+            ...state.messages.slice(0, state.messages.length - 1),
+            { ...state.messages[state.messages.length - 1], content: messages },
+          ],
+        };
+      }
+
       return {
         ...state,
-        messages: [...state.messages, action.payload],
+        messages: [
+          ...state.messages,
+          { ...action.payload, content: [action.payload.content] },
+        ],
+      };
+
+    case RECEIVE_MESSAGE:
+      if (state.messages.length > 0 &&
+        // TODO: This should check if the author = client ID
+        state.messages[state.messages.length - 1].author === action.payload.author) {
+        messages = [
+          ...state.messages[state.messages.length - 1].content,
+          action.payload.content,
+        ];
+
+        return {
+          ...state,
+          messages: [
+            ...state.messages.slice(0, state.messages.length - 1),
+            { ...state.messages[state.messages.length - 1], content: messages },
+          ],
+        };
+      }
+
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          { ...action.payload, content: [action.payload.content] },
+        ],
       };
 
     default:

--- a/src/store/Socket/index.js
+++ b/src/store/Socket/index.js
@@ -76,6 +76,7 @@ export function socketReconnectTimeout () {
 // Reducer
 //
 function SocketReducer (state = initialState, action) {
+  console.log('SOCKET', action);
   switch (action.type) {
     default:
       return state;

--- a/src/store/UI/index.js
+++ b/src/store/UI/index.js
@@ -21,6 +21,7 @@ export function toggleSettings () {
 
 
 function UIReducer (state = initialState, action) {
+  console.log('UI', action);
   switch (action.type) {
 
     case TOGGLE_SETTINGS:


### PR DESCRIPTION
This PR goes along with [minimalchat/daemon#19](https://github.com/minimalchat/daemon/pull/19) and [minimalchat/client#22](https://github.com/minimalchat/client/pull/22)

Lots of small changes,

- Upgrade socket.io from `1.7.3` to `2.0.3`
- Added functionality to handle <Enter> to send messages, <Shift+Enter> to goto a newline
- Styled the Operator messages
- Aggregated messages together that come consecutively after another from the same author
- Socket hook on Redux to send messages from the Operator to the daemon
- Emitting `operator:typing` events

A lot of the styling and aggregating of messages from the same author have been carried over from the [client](https://github.com/minimalchat/client)


![peek 2017-06-18 10-40](https://user-images.githubusercontent.com/563301/27261530-c66edd2a-5412-11e7-839c-35be820777cd.gif)
