### PR TITLE
Fix honor-less Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 yarn.lock
 dist/*-linux-armv7l
+dist/*-linux-arm64
 dist/*-win32-x64
 dist/*-mas-x64
 dist/*-linux-x64

--- a/Window.js
+++ b/Window.js
@@ -44,6 +44,7 @@ module.exports = class Window {
     // be closed automatically when the JavaScript object is garbage collected.
 
     this.window = windowObject = new BrowserWindow({
+      titleBarStyle: 'hidden',
       width,
       height,
     });

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "testRegex": "((test|spec))\\.(js|jsx)$"
   },
   "dependencies": {
-    "electron": "^1.4.1",
+    "electron": "1.8.0",
     "faker": "^4.1.0",
     "file-loader": "^0.11.2",
     "moment": "^2.18.1",
@@ -79,7 +79,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "coveralls": "^2.11.14",
     "css-loader": "^0.26.1",
-    "electron-packager": "^8.5.1",
+    "electron-packager": "9.0.1",
     "enzyme": "^2.7.0",
     "enzyme-to-json": "^1.4.5",
     "eslint": "^3.10.0",

--- a/src/components/Application/Application.jsx
+++ b/src/components/Application/Application.jsx
@@ -7,21 +7,10 @@ import ClientsPanel from '../ClientsPanel/ClientsPanel.jsx';
 import MessagePanel from '../MessagePanel/MessagePanel.jsx';
 import SettingsPanel from '../SettingsPanel/SettingsPanel.jsx';
 
-import { loadChats } from '../../store/Chat';
-import { setConfig } from '../../store/Config';
-
 import './Application.css';
 
 
 class Application extends Component {
-  constructor (props) {
-    super(props);
-
-    // Setup our IPC listeners
-    // ipcRenderer.on('config', props.updateConfig);
-    // ipcRenderer.send('init-config');
-  }
-
   renderSettingsView = () => (
     <div className="App__settingsview">
       <SettingsPanel />
@@ -48,7 +37,6 @@ class Application extends Component {
 }
 
 Application.propTypes = {
-  updateConfig: PropTypes.func.isRequired,
   settingsOpen: PropTypes.bool.isRequired,
 };
 
@@ -57,16 +45,7 @@ const mapStateToProps = state => ({
   settingsOpen: state.ui.settingsOpen,
 });
 
-const mapDispatchToProps = dispatch => ({
-  updateConfig: (event, config) => {
-    // Set config
-    dispatch(setConfig(config));
-
-    // Then reload chats
-    // TODO: ^ why does this need to happen?
-    loadChats(dispatch, config);
-  },
-});
+const mapDispatchToProps = dispatch => ({ });
 
 
 export default connect(

--- a/src/components/Application/Application.jsx
+++ b/src/components/Application/Application.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { ipcRenderer } from 'electron';
 
 import OperatorPanel from '../OperatorPanel/OperatorPanel.jsx';
 import ClientsPanel from '../ClientsPanel/ClientsPanel.jsx';
 import MessagePanel from '../MessagePanel/MessagePanel.jsx';
 import SettingsPanel from '../SettingsPanel/SettingsPanel.jsx';
+
 import { loadChats } from '../../store/Chat';
 import { setConfig } from '../../store/Config';
 
@@ -18,8 +18,8 @@ class Application extends Component {
     super(props);
 
     // Setup our IPC listeners
-    ipcRenderer.on('config', props.updateConfig);
-    ipcRenderer.send('init-config');
+    // ipcRenderer.on('config', props.updateConfig);
+    // ipcRenderer.send('init-config');
   }
 
   renderSettingsView = () => (

--- a/src/components/Application/__snapshots__/Application.test.jsx.snap
+++ b/src/components/Application/__snapshots__/Application.test.jsx.snap
@@ -7,6 +7,5 @@ exports[`Chat matches snapshot 1`] = `
       "getState": [Function],
       "subscribe": [Function],
     }
-  }
-  updateConfig={[Function]} />
+  } />
 `;

--- a/src/init.jsx
+++ b/src/init.jsx
@@ -11,7 +11,7 @@ import socketInit, { socketMessageHook } from './socket.js';
 // Reducers
 import chat from './store/Chat';
 import ui from './store/UI';
-import config from './store/Config';
+import config, { setConfig } from './store/Config';
 import socket from './store/Socket';
 
 // Create redux store
@@ -32,16 +32,16 @@ window.state = store.getState;
 // Configuration for the system
 ipcRenderer.on('config', (event, newConfig) => {
   const { dispatch } = store;
-  const { config } = store.getState();
+  const state = store.getState();
 
   dispatch(setConfig(newConfig));
 
   // Create Socket Connection only if there is a new apiServer config
-  if (newConfig.apiServer === config.apiServer) {
+  if (newConfig.apiServer === state.config.apiServer) {
     console.log('SOCKET', 'Already initialized, skipping ...');
     return;
   }
-  
+
   console.log('SOCKET', 'Initializing ...');
   socketInit(store);
 });

--- a/src/socket.js
+++ b/src/socket.js
@@ -42,7 +42,7 @@ export function socketMessageHook (store) {
 export default function socketInit (store) {
   const { dispatch } = store;
   const { config } = store.getState();
-  const socketPath = config.apiServer || 'http://192.168.86.137:8000';
+  const socketPath = config.apiServer || 'http://localhost:8000';
 
   if (!socketPath) {
     console.error('ERROR: No API Server defined', config);

--- a/src/socket.js
+++ b/src/socket.js
@@ -10,14 +10,14 @@ import {
   socketReconnectError,
   socketReconnectFailed,
   socketReconnectTimeout,
-} from './Socket';
+} from './store/Socket';
 
 import {
   addChat,
   clientTyping,
   clientIdle,
   receiveMessage,
-} from './Chat';
+} from './store/Chat';
 
 const TYPING_TIMEOUT = 1000;
 
@@ -42,7 +42,7 @@ export function socketMessageHook (store) {
 export default function socketInit (store) {
   const { dispatch } = store;
   const { config } = store.getState();
-  const socketPath = config.apiServer || 'http://localhost:8000';
+  const socketPath = config.apiServer || 'http://192.168.86.137:8000';
 
   if (!socketPath) {
     console.error('ERROR: No API Server defined', config);
@@ -53,6 +53,7 @@ export default function socketInit (store) {
   // Make connection
   socket = io.connect(socketPath, {
     reconnectionAttempts: 10,
+    transports: ['websocket'],
     query: {
       type: 'operator',
     },


### PR DESCRIPTION
This fixes #49 which was preventing the compiled electron application to work. It would try to connect before the config file was read and therefore would assume the daemon was running on `localhost:8000`.

Changes

- Moved IPC `config` and `init-config` from Application.jsx to init.jsx in root src directory.