### PR TITLE
Fixing lots of chats and no scrolling

### DIFF
--- a/src/components/ClientList/ClientList.css
+++ b/src/components/ClientList/ClientList.css
@@ -1,4 +1,6 @@
 .ClientList__list {
   margin: 0;
   padding: 0;
+  height: 100%;
+  overflow-y: auto;
 }

--- a/src/components/ClientsPanel/ClientsPanel.css
+++ b/src/components/ClientsPanel/ClientsPanel.css
@@ -1,6 +1,8 @@
 .ClientsPanel {
   background: #F7F8FA;
   box-shadow: 1px 0 1px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
   flex-grow: 2;
   z-index: 1;
 }


### PR DESCRIPTION
Operator when receiving lots of chats would extend past the size of the app and bring a second scrollbar to the side. This small change fixes said problem.