### PR TITLE
Refactor toggle menu to take a state when toggled.

### DIFF
--- a/src/components/OperatorClientMenu/OperatorClientMenu.jsx
+++ b/src/components/OperatorClientMenu/OperatorClientMenu.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import './OperatorClientMenu.css';
 import { setOperatorFilter } from '../../store/Chat';
+import { toggleSettings } from '../../store/UI';
 
 const OperatorClientMenu = (props) => {
   const { setFilter, operatorFilter, openChats } = props;
@@ -61,7 +62,10 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  setFilter: filterType => dispatch(setOperatorFilter(filterType)),
+  setFilter: filterType => {
+    dispatch(setOperatorFilter(filterType))
+    dispatch(toggleSettings(false))
+  },
 });
 
 

--- a/src/components/OperatorPanel/OperatorPanel.jsx
+++ b/src/components/OperatorPanel/OperatorPanel.jsx
@@ -36,7 +36,7 @@ OperatorPanel.propTypes = {
 
 
 const mapDispatchToProps = dispatch => ({
-  toggleSettings: () => dispatch(toggleSettings()),
+  toggleSettings: () => dispatch(toggleSettings(true)),
 });
 
 

--- a/src/store/UI/index.js
+++ b/src/store/UI/index.js
@@ -17,8 +17,8 @@ const HIDE_NOTIFICATION = 'UI_HIDE_NOTIFICATION';
 // Actions
 //
 
-export function toggleSettings () {
-  return { type: TOGGLE_SETTINGS };
+export function toggleSettings (payload) {
+  return { type: TOGGLE_SETTINGS, payload };
 }
 
 export function showNotification (payload) {
@@ -41,12 +41,8 @@ export function hideNotification () {
 
 function UIReducer (state = initialState, action) {
   switch (action.type) {
-
     case TOGGLE_SETTINGS:
-      return {
-        ...state,
-        settingsOpen: !state.settingsOpen,
-      };
+      return {...state, settingsOpen: action.payload}
 
     case SHOW_NOTIFICATION:
       return {


### PR DESCRIPTION
This enables toggling settings off when switching back to the app implicitly:
ex: settings are open; user clicks "all chats" in the sidebar filter
--> goes back to the chat.

![sep-23-2017 11-30-32](https://user-images.githubusercontent.com/12987958/30774571-a71e685a-a052-11e7-9e87-d1c75e4aee56.gif)

fixes #72 