### PR TITLE
ENV based dev tools

### DIFF
--- a/Window.js
+++ b/Window.js
@@ -51,8 +51,9 @@ module.exports = class Window {
 
     this.window.loadURL(url);
 
-    // TODO: Only use this when built using DEV environment
-    this.window.webContents.openDevTools();
+    if(process.env.NODE_ENV === "development") {
+      this.window.webContents.openDevTools();
+    }
 
     this.window.on('closed', this.onClosed);
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compile:win": "electron-packager . Operator --platform=win32 --arch=all --out=dist/",
     "compile:osx": "electron-packager . Operator --platform=darwin --platform=mas --arch=all --out=dist/",
     "compile:linux": "electron-packager . operator --platform=linux --arch=all --out=dist/",
-    "start": "electron ."
+    "start": "NODE_ENV=development electron ."
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
add environment vars ("development" for `npm start` -- currently this just prevents chrome dev tools from opening when _not_ in development mode; ie, not npm start. 