### PR TITLE
Add padding to message container

### DIFF
--- a/src/components/MessageList/MessageList.css
+++ b/src/components/MessageList/MessageList.css
@@ -30,7 +30,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  padding-bottom: 8px;
+  padding-bottom: 12px;
 }
 
 .MessageList__status {


### PR DESCRIPTION
less cut off for le messages

gifs say a 2000 words

![oct-28-2017 18-54-53](https://user-images.githubusercontent.com/12987958/32139280-4bdd1082-bc12-11e7-9d3c-8db508e81946.gif)

note i only changed to 12px because i didn't need 24 px