### PR TITLE
fix(settings): Adds a field in the settings to edit the operators name #97

### DIFF
--- a/src/components/OperatorSettingsMenu/OperatorSettingsMenu.jsx
+++ b/src/components/OperatorSettingsMenu/OperatorSettingsMenu.jsx
@@ -4,17 +4,31 @@
 */
 
 import React from 'react';
-
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import './OperatorSettingsStyles.css';
 
-
-const OperatorSettingsMenu = () => (
+const OperatorSettingsMenu = ({ operatorName }) => (
   <section className="SettingsMenu">
     <div className="Settings__box">
-      <img className="Settings__avatar" alt="billmurray" src="http://www.fillmurray.com/58/58" />
-      <span>Steve</span>
+      <img
+        className="Settings__avatar"
+        alt="billmurray"
+        src="http://www.fillmurray.com/58/58"
+      />
+      <span className="Settings__operator">{operatorName}</span>
     </div>
   </section>
 );
 
-export default OperatorSettingsMenu;
+OperatorSettingsMenu.propTypes = {
+  operatorName: PropTypes.string,
+};
+
+const mapStateToProps = state => ({
+  operatorName: state.config.operator,
+});
+
+export default connect(
+  mapStateToProps,
+)(OperatorSettingsMenu);

--- a/src/components/OperatorSettingsMenu/OperatorSettingsMenu.test.jsx
+++ b/src/components/OperatorSettingsMenu/OperatorSettingsMenu.test.jsx
@@ -7,7 +7,7 @@ import OperatorSettingsMenu from './OperatorSettingsMenu.jsx';
 const store = {
   subscribe: jest.fn(),
   dispatch: jest.fn(),
-  getState: jest.fn(() => ({ })),
+  getState: jest.fn(() => ({ config: {} })),
 };
 
 describe('OperatorSettingsMenu', () => {

--- a/src/components/OperatorSettingsMenu/OperatorSettingsStyles.css
+++ b/src/components/OperatorSettingsMenu/OperatorSettingsStyles.css
@@ -7,7 +7,7 @@
   background:  #F7F8FA;
   border-top: 1px solid  #E8ECEE;
   border-bottom: 1px solid  #E8ECEE;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
   font-size: 12px;
   color: #8f8f8f;
@@ -16,10 +16,13 @@
 
 .Settings__avatar {
   margin: 1rem;
-  margin-left: -1rem;
   border-radius: 50%;
   border: 3px solid white;
   box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.15);
   width: 58px;
   height: 58px;
+}
+
+.Settings__operator {
+  word-break: break-word;
 }

--- a/src/components/OperatorSettingsMenu/__snapshots__/OperatorSettingsMenu.test.jsx.snap
+++ b/src/components/OperatorSettingsMenu/__snapshots__/OperatorSettingsMenu.test.jsx.snap
@@ -1,20 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OperatorSettingsMenu matches snapshot 1`] = `
-<section
-  className="SettingsMenu"
->
-  <div
-    className="Settings__box"
-  >
-    <img
-      alt="billmurray"
-      className="Settings__avatar"
-      src="http://www.fillmurray.com/58/58"
-    />
-    <span>
-      Steve
-    </span>
-  </div>
-</section>
+<OperatorSettingsMenu
+  dispatch={[MockFunction]}
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+        ],
+      },
+      "subscribe": [MockFunction] {
+        "calls": Array [
+          Array [
+            [Function],
+          ],
+        ],
+      },
+    }
+  }
+/>
 `;

--- a/src/components/SettingsPanel/SettingsPanel.css
+++ b/src/components/SettingsPanel/SettingsPanel.css
@@ -18,17 +18,40 @@
   margin: 2rem;
   border-radius: 2px;
   display: flex;
+  flex-direction: column;
 }
 
 .Settings__single {
   display: flex;
   margin: 1rem 0;
   align-content: center;
+  justify-content: space-between;
 }
 
 .Settings__notification-label {
   font-size: 18px;
   color: #919191;
   align-self: center;
-  padding-left: 1rem;
+}
+
+.Settings__operator-label {
+  font-size: 18px;
+  color: #919191;
+  align-self: center;
+  padding-right: 1rem;
+  flex-grow: 3;
+}
+
+.Settings__operator-name {
+  outline: 0;
+  display: flex;
+  padding: 0.8rem;
+  resize: none;
+  border: none;
+  border-radius: 2px;
+  flex-grow: 2;
+}
+
+.Settings__operator-name:focus {
+  outline-offset: 0;
 }

--- a/src/components/SettingsPanel/SettingsPanel.jsx
+++ b/src/components/SettingsPanel/SettingsPanel.jsx
@@ -9,7 +9,7 @@ import '../Toggle/index.css';
 import './SettingsPanel.css';
 
 const SettingsPanel = (props) => {
-  const { notificationsEnabled, changeSettings } = props;
+  const { notificationsEnabled, changeSettings, operator } = props;
 
   return (
     <div className="Settings">
@@ -17,11 +17,20 @@ const SettingsPanel = (props) => {
 
       <section className="Settings__body">
         <div className="Settings__single">
+          <div className="Settings__operator-label">Operator</div>
+          <input
+            value={operator}
+            className="Settings__operator-name"
+            placeholder="Name of operator"
+            onChange={ev => changeSettings({ operator: ev.currentTarget.value })}
+          />
+        </div>
+        <div className="Settings__single">
+          <div className="Settings__notification-label">Disable notifications</div>
           <Toggle
             checked={notificationsEnabled}
             onChange={() => changeSettings({ notificationsEnabled: !notificationsEnabled })}
           />
-          <div className="Settings__notification-label">Disable notifications</div>
         </div>
       </section>
     </div>
@@ -31,10 +40,12 @@ const SettingsPanel = (props) => {
 SettingsPanel.propTypes = {
   notificationsEnabled: PropTypes.bool,
   changeSettings: PropTypes.func.isRequired,
+  operator: PropTypes.string,
 };
 
 const mapStateToProps = state => ({
   notificationsEnabled: state.config.notificationsEnabled,
+  operator: state.config.operator,
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION

<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


## Description
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Adds a input field in the settings panel to change operator name, updates it in config.json and store on change event of the input box. #97 

### Motivation
<!-- Why are these changes necessary? -->
currently the operator name is static `Steve` in template.
### Changes
<!-- How were these changes implemented? -->
- updated operator settings menu component to use operator name from props
- added a input box to input name and passed its value to existing handler `changeSettings`


<!-- 
Feel free to add additional comments

Or Screenshots (bonus points for this!)
-->
